### PR TITLE
Additional rate type

### DIFF
--- a/includes/class-igq-integration.php
+++ b/includes/class-igq-integration.php
@@ -1423,6 +1423,19 @@ class Affiliate_WP_IGQ extends Affiliate_WP_Base {
 				?>
 
 			</div>
+            <div>
+                <?php
+                woocommerce_wp_text_input(
+                    array(
+                        'id'          => 'igq_product_cost_field',
+                        'label'       => __( 'Net Subtraction', 'woocommerce' ),
+                        'desc_tip'    => 'true',
+                        'description' => __( 'Enter the cost of the product here.', 'woocommerce' ),
+                        'data_type' => 'price',
+                    )
+                );
+                ?>
+            </div>
 		</div>
 		<?php
 	}
@@ -1433,6 +1446,10 @@ class Affiliate_WP_IGQ extends Affiliate_WP_Base {
 		} else {
 			update_post_meta( $post_id, 'igq_assigned_affiliate', absint( $_POST['igq_assigned_affiliate'] ) );
 		}
+
+		if (isset($_POST['igq_product_cost_field'])) {
+		    update_post_meta($post_id, 'igq_product_cost_field', $_POST['igq_product_cost_field']);
+        }
 	}
 
 	public function allow_self_referrals( $valid, $affiliate_id ) {

--- a/includes/class-igq-integration.php
+++ b/includes/class-igq-integration.php
@@ -1497,11 +1497,12 @@ class Affiliate_WP_IGQ extends Affiliate_WP_Base {
 
             $cost = $type = get_post_meta( $product_id, 'igq_product_cost_field', true );
             if (!is_numeric($cost) || $cost <= 0) {
-                $cost = 16; // Hardcoded Default safety net.
+                $cost = 13; // Hardcoded Default safety net.
             }
 
+            // Retrieve quantities of products for net calculation
             if (empty($this->igq_item_quantities)) {
-                $items = $this->order->get_items('line_item'); // Line Items?
+                $items = $this->order->get_items('line_item');
                 $item_qnty = [];
 
                 foreach ( $items as $key => $value) {
@@ -1509,16 +1510,22 @@ class Affiliate_WP_IGQ extends Affiliate_WP_Base {
                         $product = $value->get_product();
                         $product_id = $product->get_id();
 
-
                         $item_qnty[$product_id] = $value->get_quantity();
                     }
                 }
+
                 $this->igq_item_quantities = $item_qnty;
             }
 
-            $quantity = $this->igq_item_quantities[$product_id];
+            // Set quantity to 1 by default and overwrite if exists.
+            $quantity = 1;
+            if (isset($this->igq_item_quantities[$product_id])) {
+                $quantity = $this->igq_item_quantities[$product_id];
+            }
+
+            // Calculate actual referral amount
             $referral_amount = $amount - ($cost * $quantity);
-            
+
             $this->order->add_order_note( sprintf( __( 'Net Referral Calculation: Amount (%1$s) - Cost (%2$s) * Quantity (%3$s) = Referral Amount (%4$d).', 'affiliate-wp' ),
                 $amount,
                 (string) $cost,

--- a/includes/class-igq-integration.php
+++ b/includes/class-igq-integration.php
@@ -1506,7 +1506,7 @@ class Affiliate_WP_IGQ extends Affiliate_WP_Base {
                 $item_qnty = [];
 
                 foreach ( $items as $key => $value) {
-                    if (is_a($value, WC_Order_Item::class)) {
+                    if ($value instanceof WC_Order_Item_Product) {
                         $product = $value->get_product();
                         $product_id = $product->get_id();
 

--- a/includes/class-igq-integration.php
+++ b/includes/class-igq-integration.php
@@ -95,6 +95,7 @@ class Affiliate_WP_IGQ extends Affiliate_WP_Base {
 
 		// Net Rate Addition
         add_filter( 'affwp_get_affiliate_rate_types', array($this, 'add_net_rate_type') );
+        add_filter( 'affwp_calc_referral_amount', array($this, 'affwp_calc_referral_amount_net'), 11, 5 );
 	}
 
 	/**
@@ -1469,6 +1470,35 @@ class Affiliate_WP_IGQ extends Affiliate_WP_Base {
         return $rates;
     }
 
+    /**
+     * Adding Referral Amount logic for the Net contributors and products.
+     *
+     * @param $referral_amount
+     * @param $affiliate_id
+     * @param $amount
+     * @param $reference
+     * @param $product_id
+     *
+     * @return int|string
+     */
+    public function affwp_calc_referral_amount_net($referral_amount, $affiliate_id, $amount, $reference, $product_id) {
+	    $affiliate_rate_type = affwp_get_affiliate_rate_type( $affiliate_id );
+        $product_rate_type = get_post_meta( $product_id, '_affwp_' . $this->context . '_product_rate_type', true );
+
+        // For Net affiliates/products, the referral amount will be the amount spent on the product
+        // minus the cost of the product.
+        if ($affiliate_rate_type === 'net' || $product_rate_type === 'net') {
+
+            $cost = $type = get_post_meta( $product_id, 'igq_product_cost_field', true );
+            if (!is_numeric($cost) || $cost <= 0) {
+                $cost = 16; // Hardcoded Default safety net.
+            }
+
+            $referral_amount = $amount - $cost;
+        }
+
+        return $referral_amount;
+    }
 }
 
 if ( class_exists( 'WooCommerce' ) ) {

--- a/includes/class-igq-integration.php
+++ b/includes/class-igq-integration.php
@@ -93,6 +93,8 @@ class Affiliate_WP_IGQ extends Affiliate_WP_Base {
 		add_filter( 'woocommerce_admin_order_preview_get_order_details', array( $this, 'order_preview_get_referral' ), 10, 2 );
 		add_action( 'woocommerce_admin_order_preview_end', array( $this, 'render_order_preview_referral' ) );
 
+		// Net Rate Addition
+        add_filter( 'affwp_get_affiliate_rate_types', array($this, 'add_net_rate_type') );
 	}
 
 	/**
@@ -1436,6 +1438,19 @@ class Affiliate_WP_IGQ extends Affiliate_WP_Base {
 	public function allow_self_referrals( $valid, $affiliate_id ) {
 		return true;
 	}
+
+
+    /**
+     * Add this values for the 'New Rate' of referral pay.
+     *
+     * @param array $rates
+     *
+     * @return array
+     */
+	public function add_net_rate_type(array $rates ) {
+        $rates['net'] = sprintf( __( 'Net %s', 'affiliate-wp' ), affwp_get_currency() );
+        return $rates;
+    }
 
 }
 

--- a/includes/class-igq-integration.php
+++ b/includes/class-igq-integration.php
@@ -1517,18 +1517,8 @@ class Affiliate_WP_IGQ extends Affiliate_WP_Base {
             }
 
             $quantity = $this->igq_item_quantities[$product_id];
-
-            $this->order->add_order_note(
-                json_encode([
-                   "amount" => $amount,
-                   "cost" => $cost,
-                   "quantity" => $quantity,
-                ])
-            );
-
             $referral_amount = $amount - ($cost * $quantity);
-
-
+            
             $this->order->add_order_note( sprintf( __( 'Net Referral Calculation: Amount (%1$s) - Cost (%2$s) * Quantity (%3$s) = Referral Amount (%4$d).', 'affiliate-wp' ),
                 $amount,
                 (string) $cost,


### PR DESCRIPTION
For the IGQ Integration, we truly want 100% of the proceeds to be pushed towards our affiliates. in order for this to be the case, we need to set the cost of the product and subtract the cost from the amount given. For normal response to this problem would be to use the Flat Rate functionality of AffiliateWP. However, the addition of the WooCommerce Name Your Price plugin removes that as an option. The amount that the product costs was vary depending on how much the end user wants to spend on the product. Therefore we set a cost to be subtracted from the total amount, with the remaining value being passed to the affiliate. 